### PR TITLE
fix: statement to verify that the desired flow's index exists

### DIFF
--- a/src/State.php
+++ b/src/State.php
@@ -30,7 +30,11 @@ class State
             throw new BadFunctionCallException("Method not allowed on stacks (State::canBe)");
         }
 
-        return in_array($target, $this->flows[$this->class]);
+        if (isset($this->flows[$this->class])) {
+            return in_array($target, $this->flows[$this->class]);
+        }
+
+        return false;
     }
 
     public function allowedTo(): array


### PR DESCRIPTION
An error was thrown when trying to check if a State could be another while the other one wasn't declared in the Model's Flow to have transitions.

e.g.
```php
// App\Models\Cart.php

class Cart extends Model
{
    // ...

    protected function cartFlow()
    {
        return (new Flow(self::$status))
            ->add(Opened::class, [
                Pending::class,
                Cancelled::class,
            ->add(Pending::class, [
                Opened::class,
            ])->default(Opened::class);
    }
}
```

```php
// Somewhere

// $cart->status current value is Cancelled::class
if ($cart->status->canBe(Opened::class)) { /* ... */ } // Undefined index: App\\Models\\States\\Cart\\Cancelled
```